### PR TITLE
refactor: address code review feedback for auth and current user API (#11)

### DIFF
--- a/drizzle/0005_noisy_prowler.sql
+++ b/drizzle/0005_noisy_prowler.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `sessions` ADD `expires_at` timestamp;

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,145 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "f91ad3c7-5389-4842-9c18-c869ac9d3bc9",
+  "prevId": "f4faf54b-cf82-49f6-a603-dbfb7dd131ef",
+  "tables": {
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "sessions_id": {
+          "name": "sessions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "users_id": {
+          "name": "users_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1777001823535,
       "tag": "0004_outgoing_wolfsbane",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "5",
+      "when": 1785622039384,
+      "tag": "0005_noisy_prowler",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -13,4 +13,6 @@ export const sessions = mysqlTable("sessions", {
   token: varchar("token", { length: 255 }).notNull(),
   userId: bigint("user_id", { mode: "number", unsigned: true }).notNull().references(() => users.id),
   createdAt: timestamp("created_at").defaultNow(),
+  expiresAt: timestamp("expires_at"),
 });
+

--- a/src/errors/app-error.ts
+++ b/src/errors/app-error.ts
@@ -1,0 +1,24 @@
+export class AppError extends Error {
+  constructor(message: string, public statusCode: number = 400) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}
+
+export class BadRequestError extends AppError {
+  constructor(message: string) {
+    super(message, 400);
+  }
+}
+
+export class UnauthorizedError extends AppError {
+  constructor(message: string = "Unauthorized") {
+    super(message, 401);
+  }
+}
+
+export class NotFoundError extends AppError {
+  constructor(message: string = "Not Found") {
+    super(message, 404);
+  }
+}

--- a/src/routes/users-route.ts
+++ b/src/routes/users-route.ts
@@ -1,5 +1,13 @@
 import { Elysia, t } from "elysia";
 import { registerUser, loginUser, getCurrentUser } from "../services/user-service";
+import { AppError, UnauthorizedError } from "../errors/app-error";
+
+export function extractBearerToken(authorization?: string): string | null {
+  if (!authorization || !authorization.startsWith("Bearer ")) {
+    return null;
+  }
+  return authorization.split(" ")[1] || null;
+}
 
 export const usersRoute = new Elysia()
   .post(
@@ -8,9 +16,9 @@ export const usersRoute = new Elysia()
       try {
         const result = await registerUser(body);
         return result;
-      } catch (error: any) {
-        if (error.message === "Email sudah terdaftar") {
-          set.status = 400;
+      } catch (error: unknown) {
+        if (error instanceof AppError) {
+          set.status = error.statusCode;
           return { error: error.message };
         }
         set.status = 500;
@@ -31,9 +39,9 @@ export const usersRoute = new Elysia()
       try {
         const result = await loginUser(body);
         return result;
-      } catch (error: any) {
-        if (error.message === "Email atau password salah") {
-          set.status = 401;
+      } catch (error: unknown) {
+        if (error instanceof AppError) {
+          set.status = error.statusCode;
           return { error: error.message };
         }
         set.status = 500;
@@ -51,23 +59,45 @@ export const usersRoute = new Elysia()
     "/api/users/current",
     async ({ headers, set }) => {
       try {
-        const authHeader = headers.authorization;
-        const token = authHeader?.startsWith("Bearer ") ? authHeader.split(" ")[1] : null;
+        const token = extractBearerToken(headers.authorization);
 
         if (!token) {
-          set.status = 401;
-          return { error: "Unauthorized" };
+          throw new UnauthorizedError("Unauthorized");
         }
 
         const result = await getCurrentUser(token);
         return result;
-      } catch (error: any) {
-        if (error.message === "Unauthorized") {
-          set.status = 401;
+      } catch (error: unknown) {
+        if (error instanceof AppError) {
+          set.status = error.statusCode;
           return { error: error.message };
         }
         set.status = 500;
         return { error: "Internal Server Error" };
       }
+    },
+    {
+      headers: t.Object(
+        {
+          authorization: t.String({ error: "Authorization header with Bearer token is required" }),
+        },
+        { allowUnknownHeaders: true }
+      ),
+      response: {
+        200: t.Object({
+          data: t.Object({
+            id: t.Number(),
+            name: t.String(),
+            email: t.String(),
+            created_at: t.Any(),
+          }),
+        }),
+        401: t.Object({
+          error: t.String(),
+        }),
+        500: t.Object({
+          error: t.String(),
+        }),
+      },
     }
   );

--- a/src/services/user-service.ts
+++ b/src/services/user-service.ts
@@ -1,6 +1,7 @@
 import { db } from "../db";
 import { users, sessions } from "../db/schema";
 import { eq } from "drizzle-orm";
+import { BadRequestError, UnauthorizedError } from "../errors/app-error";
 
 export async function registerUser(payload: any) {
   // Check if email already exists
@@ -9,7 +10,7 @@ export async function registerUser(payload: any) {
   });
 
   if (existingUser) {
-    throw new Error("Email sudah terdaftar");
+    throw new BadRequestError("Email sudah terdaftar");
   }
 
   // Hash password
@@ -34,20 +35,22 @@ export async function loginUser(payload: any) {
   });
 
   if (!user) {
-    throw new Error("Email atau password salah");
+    throw new UnauthorizedError("Email atau password salah");
   }
 
   const isPasswordValid = await Bun.password.verify(payload.password, user.password);
 
   if (!isPasswordValid) {
-    throw new Error("Email atau password salah");
+    throw new UnauthorizedError("Email atau password salah");
   }
 
   const token = crypto.randomUUID();
+  const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000); // 7 days expiration
 
   await db.insert(sessions).values({
     token: token,
     userId: user.id,
+    expiresAt: expiresAt,
   });
 
   return { data: token };
@@ -55,7 +58,7 @@ export async function loginUser(payload: any) {
 
 export async function getCurrentUser(token: string) {
   if (!token) {
-    throw new Error("Unauthorized");
+    throw new UnauthorizedError("Unauthorized");
   }
 
   const session = await db.query.sessions.findFirst({
@@ -63,7 +66,11 @@ export async function getCurrentUser(token: string) {
   });
 
   if (!session) {
-    throw new Error("Unauthorized");
+    throw new UnauthorizedError("Unauthorized");
+  }
+
+  if (session.expiresAt && session.expiresAt < new Date()) {
+    throw new UnauthorizedError("Session expired");
   }
 
   const user = await db.query.users.findFirst({
@@ -71,7 +78,7 @@ export async function getCurrentUser(token: string) {
   });
 
   if (!user) {
-    throw new Error("Unauthorized");
+    throw new UnauthorizedError("Unauthorized");
   }
 
   return {

--- a/src/users-route.test.ts
+++ b/src/users-route.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { extractBearerToken } from "./routes/users-route";
+import { AppError, UnauthorizedError, BadRequestError } from "./errors/app-error";
+
+describe("Authentication & Error Helpers", () => {
+  it("should correctly extract Bearer token from authorization header", () => {
+    const token = extractBearerToken("Bearer sample-token-123");
+    expect(token).toBe("sample-token-123");
+  });
+
+  it("should return null if Bearer prefix is missing or invalid", () => {
+    expect(extractBearerToken("Basic sample-token-123")).toBeNull();
+    expect(extractBearerToken("sample-token-123")).toBeNull();
+    expect(extractBearerToken(undefined)).toBeNull();
+  });
+
+  it("should instantiate custom AppError classes with correct status codes", () => {
+    const appErr = new AppError("Generic error", 400);
+    expect(appErr.statusCode).toBe(400);
+
+    const unauthErr = new UnauthorizedError();
+    expect(unauthErr.statusCode).toBe(401);
+    expect(unauthErr.message).toBe("Unauthorized");
+
+    const badReqErr = new BadRequestError("Invalid input");
+    expect(badReqErr.statusCode).toBe(400);
+    expect(badReqErr.message).toBe("Invalid input");
+  });
+});


### PR DESCRIPTION
Closes #11

## Summary of Changes
- 🛡️ **Session Expiration:** Added `expiresAt` timestamp column to `sessions` schema and verified `session.expiresAt > new Date()` in `getCurrentUser`.
- 📐 **Typed AppErrors:** Replaced raw error strings with typed `AppError` hierarchy (`UnauthorizedError`, `BadRequestError`, `NotFoundError`).
- 🛠️ **Authorization Header Extraction:** Extracted `extractBearerToken` helper function.
- 📋 **Schema Validation:** Added Elysia request header and response payload schemas for `GET /api/users/current`.
- 🧪 **Unit Tests:** Added tests for authentication helpers and custom errors.